### PR TITLE
Fix dependencies for awssum-amazon-* packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,10 +14,8 @@
   },
   "dependencies": {
     "awsbox": "0.4.4",
-    "awssum": "1.0.0-beta",
-    "awssum-amazon": "1.0.2",
-    "awssum-amazon-cloudformation": "1.0.0",
-    "awssum-amazon-ec2": "1.0.0",
+    "awssum-amazon-cloudformation": "1.0.x",
+    "awssum-amazon-ec2": "1.0.x",
     "docopt": "0.4.0",
     "js-yaml": "2.0.4",
     "async": "0.2.5",


### PR DESCRIPTION
Since AwsSum has a plugin architecture, each plugin depends on awssum
itself. Using the new peerDependencies each package pulls in awssum
alongside itself. Also, each awssum-<provider>-<service> package also
pulls in the relevant awssum-<provider> package too.

Finally, using semver, it pays to depend on the v1.0.x patch series,
rather than sticking with a fixed version number.
